### PR TITLE
Correct common misconception about Muffin

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,0 @@
-Muffin
-======
-
-The Cinnamon Window Manager
-
-Based on Mutter 3.2.1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+### Muffin
+
+The Cinnamon Window Manager
+
+Based on Mutter 3.2.1
+
+The standalone `muffin` binary is not used by the Cinnamon desktop, and is mainly a code example, but may sometimes be used for troubleshooting.  Cinnamon is its own window manager, and uses the muffin libraries (compiled from this source tree, and whose binaries are also available in APT package `muffin-common`) to perform this task.  
+
+Therefore, you can’t just use a different window manager or compositor with Cinnamon (this is the same architecture as in gnome-shell, from which Cinnamon is derived).  


### PR DESCRIPTION
The Web is full of statements that "Cinnamon's window manager is Muffin", but 
looking at a list of running processes on a Cinnamon system shows only 
  `cinnamon --replace` 
instead of Muffin.  This commit should help clarify that.  

Text is modified from mtwebster's comment of 2013-07-12 on the following blog 
page:  
http://segfault.linuxmint.com/2013/07/new-window-tiling-and-snapping-functionality/